### PR TITLE
Disabled 'important' csslint rule

### DIFF
--- a/tasks/css.js
+++ b/tasks/css.js
@@ -55,7 +55,8 @@ module.exports = function (grunt) {
             'vendor-prefix'                 : false,
             'adjoining-classes'             : false,
             'universal-selector'            : false,
-            'force'                         : true
+            'force'                         : true,
+            'important'                     : false
         },
         src: ['./content/<%= config.wrapper %>/common/css/main.css']
     });


### PR DESCRIPTION
So `grunt` doesn't fail and `--force` isn't required.
